### PR TITLE
Add bash and curl to use circleci/slack orb on CircleCI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN wget https://github.com/h3poteto/ecs-goploy/releases/download/${ECS_GOPLOY_V
 
 FROM alpine:3.9
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates bash curl
 COPY --from=builder /usr/local/bin/ecs-goploy /usr/local/bin/ecs-goploy
 ENTRYPOINT ["ecs-goploy"]


### PR DESCRIPTION
I want to notify slack when deploy failed.
I'll use `circleci/slack` orb, but it depends on bash and curl.
So I added them to the image.
https://circleci.com/orbs/registry/orb/circleci/slack
